### PR TITLE
closes #1, Implement a basic system for triggering plot flags

### DIFF
--- a/Assets/Prefabs/Conversations/ArchibaldConversation1.prefab
+++ b/Assets/Prefabs/Conversations/ArchibaldConversation1.prefab
@@ -11,6 +11,23 @@ Prefab:
   m_ParentPrefab: {fileID: 0}
   m_RootGameObject: {fileID: 1421757032374982}
   m_IsPrefabParent: 1
+--- !u!1 &1166436083198960
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4594531566033686}
+  - component: {fileID: 114171034797532400}
+  - component: {fileID: 114446346927767608}
+  m_Layer: 0
+  m_Name: 'Archibald: Nice filter'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &1314220350634970
 GameObject:
   m_ObjectHideFlags: 1
@@ -95,18 +112,18 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1581646958810568
+--- !u!1 &1544573017658536
 GameObject:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 4641631073093950}
-  - component: {fileID: 114479450231963754}
-  - component: {fileID: 114919399775111532}
+  - component: {fileID: 4453572840097928}
+  - component: {fileID: 114671213669250690}
+  - component: {fileID: 114152841281759958}
   m_Layer: 0
-  m_Name: 'Archibald: mean'
+  m_Name: PC:I am a mean player
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -140,7 +157,7 @@ GameObject:
   - component: {fileID: 114765279445150534}
   - component: {fileID: 114729346469911672}
   m_Layer: 0
-  m_Name: 'Archibald: What a nice day tomorrow'
+  m_Name: 'Archibald: What a nice day tomorrow yes lovely'
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -156,8 +173,9 @@ GameObject:
   - component: {fileID: 4794216235835214}
   - component: {fileID: 114994786705596072}
   - component: {fileID: 114780041829976332}
+  - component: {fileID: 114761327995214894}
   m_Layer: 0
-  m_Name: PC:really?
+  m_Name: PC:I'm sorry
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -173,8 +191,27 @@ GameObject:
   - component: {fileID: 4065127701367786}
   - component: {fileID: 114289395260176146}
   - component: {fileID: 114839158863392294}
+  - component: {fileID: 114273252748273114}
   m_Layer: 0
   m_Name: PC:Nope, not nice at all.
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &1802996059212264
+GameObject:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4935996558617682}
+  - component: {fileID: 114160059645464892}
+  - component: {fileID: 114234466885488646}
+  - component: {fileID: 114516408868481704}
+  m_Layer: 0
+  m_Name: 'Archibald: Mean filkter'
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -219,9 +256,23 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 4641631073093950}
+  m_Children: []
   m_Father: {fileID: 4819054781230822}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4453572840097928
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1544573017658536}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 4594531566033686}
+  - {fileID: 4935996558617682}
+  m_Father: {fileID: 4965884096549200}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4472000670712844
@@ -251,17 +302,17 @@ Transform:
   m_Father: {fileID: 4162994318770800}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &4641631073093950
+--- !u!4 &4594531566033686
 Transform:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1581646958810568}
+  m_GameObject: {fileID: 1166436083198960}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 4343054595232902}
+  m_Father: {fileID: 4453572840097928}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4705124624490870
@@ -306,6 +357,19 @@ Transform:
   m_Father: {fileID: 4065127701367786}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!4 &4935996558617682
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1802996059212264}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4453572840097928}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &4965884096549200
 Transform:
   m_ObjectHideFlags: 1
@@ -315,7 +379,8 @@ Transform:
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 4453572840097928}
   m_Father: {fileID: 4705124624490870}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -342,8 +407,47 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dialogOne: Yes, lovely
-  linkedDialogOne: {fileID: 0}
+  npcResponse: []
   keycode: 95
+--- !u!114 &114152841281759958
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1544573017658536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2614512f7f35b47a480d332c220b48af, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &114160059645464892
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1802996059212264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 461c2395afe244e17b13b54d607a74c4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  npcResponse: Mean filkter
+  linkedDialogOne: []
+  plotFilter: {fileID: 0}
+--- !u!114 &114171034797532400
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1166436083198960}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 461c2395afe244e17b13b54d607a74c4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  npcResponse: Nice filter
+  linkedDialogOne: []
+  plotFilter: {fileID: 0}
 --- !u!114 &114185971820790088
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -364,6 +468,18 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
+  plotManager: {fileID: 0}
+--- !u!114 &114234466885488646
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1802996059212264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2614512f7f35b47a480d332c220b48af, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &114246309512870304
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -375,6 +491,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2614512f7f35b47a480d332c220b48af, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &114273252748273114
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1747212678684402}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48538c378bf8b4038ab71086eb35002c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plot: {fileID: 0}
+  newValue: no
 --- !u!114 &114289395260176146
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -387,21 +516,32 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dialogOne: Nope, not nice at all.
-  linkedDialogOne: {fileID: 0}
+  npcResponse: []
   keycode: 95
---- !u!114 &114479450231963754
+--- !u!114 &114446346927767608
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1581646958810568}
+  m_GameObject: {fileID: 1166436083198960}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 461c2395afe244e17b13b54d607a74c4, type: 3}
+  m_Script: {fileID: 11500000, guid: 2614512f7f35b47a480d332c220b48af, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  npcResponse: mean
-  linkedDialogOne: []
+--- !u!114 &114516408868481704
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1802996059212264}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 957bb29fdad124ce198b6640437a07fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plot: {fileID: 0}
+  expectedValue: no
 --- !u!114 &114543370695787274
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -425,7 +565,21 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dialogOne: Maybe.
-  linkedDialogOne: {fileID: 0}
+  npcResponse: []
+  keycode: 95
+--- !u!114 &114671213669250690
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1544573017658536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 148cc504807b74295b0fd8e7b660e449, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  dialogOne: I am a mean player
+  npcResponse: []
   keycode: 95
 --- !u!114 &114708616523812950
 MonoBehaviour:
@@ -439,7 +593,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   dialogOne: I know you are but what am i?
-  linkedDialogOne: {fileID: 0}
+  npcResponse:
+  - {fileID: 114791426648425948}
   keycode: 95
 --- !u!114 &114720114326710910
 MonoBehaviour:
@@ -474,6 +629,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2614512f7f35b47a480d332c220b48af, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &114761327995214894
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1725516975972220}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48538c378bf8b4038ab71086eb35002c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plot: {fileID: 0}
+  newValue: yes
 --- !u!114 &114765279445150534
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -485,8 +653,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 461c2395afe244e17b13b54d607a74c4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  npcResponse: What a nice day tomorrow
+  npcResponse: What a nice day tomorrow yes lovely
   linkedDialogOne: []
+  plotFilter: {fileID: 0}
 --- !u!114 &114780041829976332
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -511,6 +680,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   npcResponse: Did you see the willows?
   linkedDialogOne: []
+  plotFilter: {fileID: 0}
 --- !u!114 &114836089134946420
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -524,23 +694,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   npcResponse: What a kill joy.
   linkedDialogOne: []
+  plotFilter: {fileID: 0}
 --- !u!114 &114839158863392294
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1747212678684402}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2614512f7f35b47a480d332c220b48af, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &114919399775111532
-MonoBehaviour:
-  m_ObjectHideFlags: 1
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 1581646958810568}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2614512f7f35b47a480d332c220b48af, type: 3}
@@ -557,6 +717,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 148cc504807b74295b0fd8e7b660e449, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  dialogOne: really?
-  linkedDialogOne: {fileID: 0}
+  dialogOne: I'm sorry
+  npcResponse: []
   keycode: 95

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -325,6 +325,113 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 224524496}
+--- !u!1001 &226926417
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1333706490}
+    m_Modifications:
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114174940163999194, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7,
+        type: 2}
+      propertyPath: npcResponse
+      value: hjchbvcjkhbjk
+      objectReference: {fileID: 0}
+    - target: {fileID: 1381438566296464, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_Name
+      value: 'Archibald: hjchbvcjkhbjk'
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &226926418 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7,
+    type: 2}
+  m_PrefabInternal: {fileID: 226926417}
+--- !u!1001 &402302531
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1033774101}
+    m_Modifications:
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1381438566296464, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_Name
+      value: 'Archibald: Mean filkter'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114174940163999194, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7,
+        type: 2}
+      propertyPath: npcResponse
+      value: Mean filkter
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1 &421489146
 GameObject:
   m_ObjectHideFlags: 0
@@ -597,7 +704,58 @@ Transform:
 Transform:
   m_PrefabParentObject: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72,
     type: 2}
-  m_PrefabInternal: {fileID: 1371492856}
+  m_PrefabInternal: {fileID: 1033774100}
+--- !u!1001 &788141458
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1033774101}
+    m_Modifications:
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4629999648711404, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1381438566296464, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+      propertyPath: m_Name
+      value: 'Archibald: Nice filter'
+      objectReference: {fileID: 0}
+    - target: {fileID: 114174940163999194, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7,
+        type: 2}
+      propertyPath: npcResponse
+      value: Nice filter
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: d3aaaa79e7afe4186b4b5ecfd29a8df7, type: 2}
+  m_IsPrefabParent: 0
 --- !u!1 &840932438
 GameObject:
   m_ObjectHideFlags: 0
@@ -606,6 +764,7 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 840932439}
+  - component: {fileID: 840932441}
   m_Layer: 0
   m_Name: PlotManager
   m_TagString: Untagged
@@ -622,10 +781,22 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 1865784320}
   m_Father: {fileID: 0}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &840932441
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 840932438}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b673eadbe6ce64660bc74f9a4fd55e98, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &944718548
 GameObject:
   m_ObjectHideFlags: 0
@@ -684,6 +855,104 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1030372831 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 114791426648425948, guid: a4a1760d10d054813b806c22bf889b72,
+    type: 2}
+  m_PrefabInternal: {fileID: 1033774100}
+  m_Script: {fileID: 11500000, guid: 461c2395afe244e17b13b54d607a74c4, type: 3}
+--- !u!1001 &1033774100
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1372850223}
+    m_Modifications:
+    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: -3.07
+      objectReference: {fileID: 0}
+    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0.38
+      objectReference: {fileID: 0}
+    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114761327995214894, guid: a4a1760d10d054813b806c22bf889b72,
+        type: 2}
+      propertyPath: plot
+      value: 
+      objectReference: {fileID: 1865784321}
+    - target: {fileID: 114185971820790088, guid: a4a1760d10d054813b806c22bf889b72,
+        type: 2}
+      propertyPath: npc
+      value: 
+      objectReference: {fileID: 1372850222}
+    - target: {fileID: 114185971820790088, guid: a4a1760d10d054813b806c22bf889b72,
+        type: 2}
+      propertyPath: player
+      value: 
+      objectReference: {fileID: 193748940}
+    - target: {fileID: 114185971820790088, guid: a4a1760d10d054813b806c22bf889b72,
+        type: 2}
+      propertyPath: npcText
+      value: 
+      objectReference: {fileID: 1662018962}
+    - target: {fileID: 114185971820790088, guid: a4a1760d10d054813b806c22bf889b72,
+        type: 2}
+      propertyPath: playerResponseTexts.Array.data[0]
+      value: 
+      objectReference: {fileID: 1286649693}
+    - target: {fileID: 114185971820790088, guid: a4a1760d10d054813b806c22bf889b72,
+        type: 2}
+      propertyPath: playerResponseTexts.Array.data[1]
+      value: 
+      objectReference: {fileID: 224524498}
+    - target: {fileID: 114185971820790088, guid: a4a1760d10d054813b806c22bf889b72,
+        type: 2}
+      propertyPath: playerResponseTexts.Array.data[2]
+      value: 
+      objectReference: {fileID: 2085399752}
+    - target: {fileID: 114273252748273114, guid: a4a1760d10d054813b806c22bf889b72,
+        type: 2}
+      propertyPath: plot
+      value: 
+      objectReference: {fileID: 1865784321}
+    - target: {fileID: 114708616523812950, guid: a4a1760d10d054813b806c22bf889b72,
+        type: 2}
+      propertyPath: npcResponse
+      value: 
+      objectReference: {fileID: 1030372831}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &1033774101 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4453572840097928, guid: a4a1760d10d054813b806c22bf889b72,
+    type: 2}
+  m_PrefabInternal: {fileID: 1033774100}
 --- !u!1 &1286649691
 GameObject:
   m_ObjectHideFlags: 0
@@ -758,78 +1027,54 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1286649691}
---- !u!1001 &1371492856
-Prefab:
+--- !u!1 &1333706489
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1372850223}
-    m_Modifications:
-    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
-      propertyPath: m_LocalPosition.x
-      value: -3.07
-      objectReference: {fileID: 0}
-    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
-      propertyPath: m_LocalPosition.y
-      value: 0.38
-      objectReference: {fileID: 0}
-    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4472000670712844, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 114185971820790088, guid: a4a1760d10d054813b806c22bf889b72,
-        type: 2}
-      propertyPath: npc
-      value: 
-      objectReference: {fileID: 1372850222}
-    - target: {fileID: 114185971820790088, guid: a4a1760d10d054813b806c22bf889b72,
-        type: 2}
-      propertyPath: player
-      value: 
-      objectReference: {fileID: 193748940}
-    - target: {fileID: 114185971820790088, guid: a4a1760d10d054813b806c22bf889b72,
-        type: 2}
-      propertyPath: npcText
-      value: 
-      objectReference: {fileID: 1662018962}
-    - target: {fileID: 114185971820790088, guid: a4a1760d10d054813b806c22bf889b72,
-        type: 2}
-      propertyPath: playerResponseTexts.Array.data[0]
-      value: 
-      objectReference: {fileID: 1286649693}
-    - target: {fileID: 114185971820790088, guid: a4a1760d10d054813b806c22bf889b72,
-        type: 2}
-      propertyPath: playerResponseTexts.Array.data[1]
-      value: 
-      objectReference: {fileID: 224524498}
-    - target: {fileID: 114185971820790088, guid: a4a1760d10d054813b806c22bf889b72,
-        type: 2}
-      propertyPath: playerResponseTexts.Array.data[2]
-      value: 
-      objectReference: {fileID: 2085399752}
-    m_RemovedComponents: []
-  m_ParentPrefab: {fileID: 100100000, guid: a4a1760d10d054813b806c22bf889b72, type: 2}
-  m_IsPrefabParent: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1333706490}
+  - component: {fileID: 1333706491}
+  m_Layer: 0
+  m_Name: Conversation 2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1333706490
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1333706489}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.07, y: 0.38, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 226926418}
+  m_Father: {fileID: 1372850223}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1333706491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1333706489}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7db2d07d97edf4b68836d88e7f967cb2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  completedResponse: 
+  currentNpcDialog: {fileID: 0}
+  npc: {fileID: 1372850222}
+  player: {fileID: 193748940}
+  npcText: {fileID: 1662018962}
+  playerResponseTexts: []
+  plotManager: {fileID: 0}
 --- !u!1 &1372850222
 GameObject:
   m_ObjectHideFlags: 0
@@ -860,6 +1105,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 1333706490}
   - {fileID: 656185241}
   m_Father: {fileID: 944718549}
   m_RootOrder: 0
@@ -1110,6 +1356,49 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1662018960}
+--- !u!1 &1865784319
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1865784320}
+  - component: {fileID: 1865784321}
+  m_Layer: 0
+  m_Name: PC_NICE
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1865784320
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1865784319}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 840932439}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1865784321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1865784319}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0b1aa36ea8885425bb7eca3914c9f993, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  plotName: PC_NICE
+  startingValue: yes
+  plotValue: 
 --- !u!1 &2085399750
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/ConversationSystem/Conversation.cs
+++ b/Assets/Scripts/ConversationSystem/Conversation.cs
@@ -3,8 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
-public class Conversation : MonoBehaviour
-{
+public class Conversation : MonoBehaviour {
 
     [TextArea]
     public string completedResponse = "";
@@ -25,75 +24,68 @@ public class Conversation : MonoBehaviour
     bool started = true;
     bool completed = false;
 
-    public NPC getNPC() {
-        return this.npc.GetComponent<NPC>();
+    public NPC getNPC () {
+        return this.npc.GetComponent<NPC> ();
     }
 
     // Use this for initialization
-    void Start()
-    {
+    void Start () {
         npc = this.transform.parent.gameObject;
-        foreach (Transform child in this.transform)
-        {
-            this.currentNpcDialog = child.GetComponent<NPCDialog>();
+        foreach (Transform child in this.transform) {
+            this.currentNpcDialog = child.GetComponent<NPCDialog> ();
         }
-        this.npcText.transform.position =  new Vector3(this.npc.transform.position.x, this.npc.transform.position.y + 0.5f, this.npcText.transform.position.z);
+        this.npcText.transform.position = new Vector3 (this.npc.transform.position.x, this.npc.transform.position.y + 0.5f, this.npcText.transform.position.z);
         this.npcText.text = this.currentNpcDialog.npcResponse;
-        Invoke("updatePlayerResponses", 2);
+        Invoke ("updatePlayerResponses", 2);
     }
 
-    void updatePlayerResponses() {
-         List<PlayerDialog> playerResponses = this.currentNpcDialog.getPlayerResponses();
-        for(int i  = 0; i < playerResponses.Count; i+=1){
-            this.playerResponseTexts[i].text = playerResponses[i].dialogOne + playerResponses[i].getKeyCode().ToString();
-            if(i == 0){
-                this.playerResponseTexts[i].transform.position =  new Vector3(this.player.transform.position.x + 2f, 
-                                                                                this.player.transform.position.y, 
-                                                                                this.playerResponseTexts[i].transform.position.z);
-            } else if(i == 1){
-                this.playerResponseTexts[i].transform.position =  new Vector3(this.player.transform.position.x - 0.5f, 
-                                                                                this.player.transform.position.y, 
-                                                                                this.playerResponseTexts[i].transform.position.z);
-            } else if(i == 2){
-                this.playerResponseTexts[i].transform.position =  new Vector3(this.player.transform.position.x, 
-                                                                                this.player.transform.position.y + 0.5f, 
-                                                                                this.playerResponseTexts[i].transform.position.z);
+    void updatePlayerResponses () {
+        List<PlayerDialog> playerResponses = this.currentNpcDialog.getPlayerResponses ();
+        for (int i = 0; i < playerResponses.Count; i += 1) {
+            this.playerResponseTexts[i].text = playerResponses[i].dialogOne + playerResponses[i].getKeyCode ().ToString ();
+            if (i == 0) {
+                this.playerResponseTexts[i].transform.position = new Vector3 (this.player.transform.position.x + 2f,
+                    this.player.transform.position.y,
+                    this.playerResponseTexts[i].transform.position.z);
+            } else if (i == 1) {
+                this.playerResponseTexts[i].transform.position = new Vector3 (this.player.transform.position.x - 0.5f,
+                    this.player.transform.position.y,
+                    this.playerResponseTexts[i].transform.position.z);
+            } else if (i == 2) {
+                this.playerResponseTexts[i].transform.position = new Vector3 (this.player.transform.position.x,
+                    this.player.transform.position.y + 0.5f,
+                    this.playerResponseTexts[i].transform.position.z);
             }
         }
     }
 
-    void hidePlayerResponseText(){
-        foreach(Text text in this.playerResponseTexts){
+    void hidePlayerResponseText () {
+        foreach (Text text in this.playerResponseTexts) {
             text.text = string.Empty;
         }
     }
 
-    void hideNpcResponse() {
+    void hideNpcResponse () {
         this.npcText.text = string.Empty;
     }
 
     // Update is called once per frame
-    void Update()
-    {
-        if (this.started && !this.completed)
-        {
-            this.currentNpcDialog.fixedUpdate();
-            if (this.currentNpcDialog.getPlayerResponse())
-            {
-                this.hidePlayerResponseText();
-                PlayerDialog playerDialog = this.currentNpcDialog.getPlayerResponse();
-                Debug.Log(playerDialog.dialogOne);
-                this.currentNpcDialog = playerDialog.getNpcResponse();
-                if(this.currentNpcDialog)
-                {
+    void Update () {
+        if (this.started && !this.completed) {
+            this.currentNpcDialog.fixedUpdate ();
+            if (this.currentNpcDialog.getPlayerResponse ()) {
+                this.hidePlayerResponseText ();
+                PlayerDialog playerDialog = this.currentNpcDialog.getPlayerResponse ();
+                this.currentNpcDialog = playerDialog.getNpcResponse ();
+                if (this.currentNpcDialog) {
                     this.npcText.text = this.currentNpcDialog.npcResponse;
-                    Invoke("updatePlayerResponses", 5);
-                    Debug.Log(this.currentNpcDialog.npcResponse);
-                    this.completed = !this.currentNpcDialog.HasPossibleResponses();
-                    
+                    Invoke ("updatePlayerResponses", 5);
+                    Debug.Log (this.currentNpcDialog.npcResponse);
+                    this.completed = !this.currentNpcDialog.HasPossibleResponses ();
+
                 } else {
-                    this.hideNpcResponse();
-                    this.hidePlayerResponseText();
+                    this.hideNpcResponse ();
+                    this.hidePlayerResponseText ();
                     this.completed = true;
                 }
             }

--- a/Assets/Scripts/ConversationSystem/NPCDialog.cs
+++ b/Assets/Scripts/ConversationSystem/NPCDialog.cs
@@ -2,85 +2,88 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class NPCDialog : MonoBehaviour
-{
-    [Header("Option 1")]
+public class NPCDialog : MonoBehaviour {
+    [Header ("Option 1")]
     [TextArea]
     public string npcResponse = "";
     [SerializeField]
-    List<PlayerDialog> linkedDialogOne = new List<PlayerDialog>();
+    List<PlayerDialog> linkedDialogOne = new List<PlayerDialog> ();
 
-    private KeyCode[] responseKeyCodes = { KeyCode.J, KeyCode.K, KeyCode.L };
-
+    private KeyCode[] responseKeyCodes = { KeyCode.A, KeyCode.W, KeyCode.D };
 
     PlayerDialog playerResponse;
 
-    public PlayerDialog getPlayerResponse()
-    {
+    [SerializeField]
+    PlotFilter plotFilter = null;
+
+    // Use this for initialization
+    void Start () {
+        this.linkedDialogOne = new List<PlayerDialog> ();
+        int i = 0;
+        foreach (Transform child in this.transform) {
+            PlayerDialog dialog = child.GetComponent<PlayerDialog> ();
+            if (dialog) {
+                dialog.setKeyCode (responseKeyCodes[i]);
+                i += 1;
+                this.linkedDialogOne.Add (dialog);
+            }
+        }
+        this.plotFilter = this.GetComponent<PlotFilter> ();
+    }
+
+    public void fixedUpdate () {
+        if (!this.playerResponse) {
+            if (Input.GetKeyDown (responseKeyCodes[0])) {
+                Debug.Log ("Hit J key");
+                this.setPlayerResponse (responseKeyCodes[0]);
+            }
+            if (Input.GetKeyDown (responseKeyCodes[1])) {
+                Debug.Log ("Hit K key");
+                this.setPlayerResponse (responseKeyCodes[1]);
+            }
+            if (Input.GetKeyDown (responseKeyCodes[2])) {
+                Debug.Log ("Hit L key");
+                this.setPlayerResponse (responseKeyCodes[2]);
+            }
+        }
+    }
+
+    /*
+        PLOT FILTERS
+    */
+
+    public bool isNpcResponse () {
+        return this.plotFilter ? this.plotFilter.isActive () : true;
+    }
+
+    public bool hasPlotFilter () {
+        return this.plotFilter != null;
+    }
+
+    /*
+        PLAYER RESPONSES
+    */
+
+    public PlayerDialog getPlayerResponse () {
         return this.playerResponse;
     }
 
-    public bool HasPossibleResponses() {
+    public bool HasPossibleResponses () {
         return this.linkedDialogOne.Count > 0;
     }
 
-    public List<PlayerDialog> getPlayerResponses() {
+    public List<PlayerDialog> getPlayerResponses () {
         return this.linkedDialogOne;
     }
 
-    // Use this for initialization
-    void Start()
-    {
-        this.name = "NPC: " + npcResponse;
-        this.linkedDialogOne = new List<PlayerDialog>();
-        int i = 0;
-        foreach (Transform child in this.transform)
-        {
-            PlayerDialog dialog = child.GetComponent<PlayerDialog>();
-            if (dialog)
-            {
-                dialog.setKeyCode(responseKeyCodes[i]);
-                i += 1;
-                this.linkedDialogOne.Add(dialog);
-            }
-        }
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-
-    }
-
-    public void fixedUpdate()
-    {
-        if (!this.playerResponse)
-        {
-            if (Input.GetKeyDown(responseKeyCodes[0]))
-            {
-                Debug.Log("Hit J key");
-                this.setPlayerResponse(responseKeyCodes[0]);
-            }
-            if (Input.GetKeyDown(responseKeyCodes[1]))
-            {
-                Debug.Log("Hit K key");
-                this.setPlayerResponse(responseKeyCodes[1]);
-            }
-            if (Input.GetKeyDown(responseKeyCodes[2]))
-            {
-                Debug.Log("Hit L key");
-                this.setPlayerResponse(responseKeyCodes[2]);
-            }
-        }
-    }
-
-    void setPlayerResponse(KeyCode keyCode)
-    {
-        foreach (PlayerDialog dialog in this.linkedDialogOne)
-        {
-            if (dialog.getKeyCode() == keyCode)
-            {
+    void setPlayerResponse (KeyCode keyCode) {
+        foreach (PlayerDialog dialog in this.linkedDialogOne) {
+            if (dialog.getKeyCode () == keyCode) {
                 this.playerResponse = dialog;
+                if (this.playerResponse.hasPlotTrigger ()) {
+                    PlotTrigger trigger = this.playerResponse.getPlotTrigger ();
+                    trigger.getPlot ().setPlotValue (trigger.getNewValue ());
+                }
                 return;
             }
         }

--- a/Assets/Scripts/ConversationSystem/PlayerDialog.cs
+++ b/Assets/Scripts/ConversationSystem/PlayerDialog.cs
@@ -2,48 +2,68 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public class PlayerDialog : MonoBehaviour
-{
-    [Header("Option 1")]
+public class PlayerDialog : MonoBehaviour {
+    [Header ("Option 1")]
     [TextArea]
     public string dialogOne = "";
     [SerializeField]
-    NPCDialog linkedDialogOne;
+    List<NPCDialog> npcResponse = new List<NPCDialog> ();
 
     [SerializeField]
     KeyCode keycode = KeyCode.Underscore;
 
-    public NPCDialog getNpcResponse()
-    {
-        return this.linkedDialogOne;
-    }
+    private PlotTrigger plotTrigger;
+
     // Use this for initialization
-    void Start()
-    {
-        foreach (Transform child in this.transform)
-        {
-            NPCDialog dialog = child.GetComponent<NPCDialog>();
-            if (dialog)
-            {
-                this.linkedDialogOne = dialog;
-                break;
+    void Start () {
+        this.plotTrigger = this.GetComponent<PlotTrigger> ();
+        if (this.npcResponse.Count < 1) {
+            foreach (Transform child in this.transform) {
+                NPCDialog dialog = child.GetComponent<NPCDialog> ();
+                if (dialog) {
+                    this.npcResponse.Add (dialog);
+                }
             }
         }
     }
 
-    // Update is called once per frame
-    void Update()
-    {
+    /*
+        NPC Response
+    */
 
+    public NPCDialog getNpcResponse () {
+        NPCDialog defaultDialog = null;
+        foreach (NPCDialog dialog in this.npcResponse) {
+            if (dialog.isNpcResponse () && dialog.hasPlotFilter ()) {
+                return dialog;
+            } else if (dialog.isNpcResponse ()) {
+                defaultDialog = dialog;
+            }
+        }
+        return defaultDialog;
     }
 
-    public void setKeyCode(KeyCode keycode)
-    {
+    /*
+        Plot Trigger
+    */
+
+    public bool hasPlotTrigger () {
+        return this.plotTrigger != null;
+    }
+
+    public PlotTrigger getPlotTrigger () {
+        return this.plotTrigger;
+    }
+
+    /*
+        Key Code
+    */
+
+    public void setKeyCode (KeyCode keycode) {
         this.keycode = keycode;
     }
 
-    public KeyCode getKeyCode()
-    {
+    public KeyCode getKeyCode () {
         return this.keycode;
     }
 }

--- a/Assets/Scripts/ConversationSystem/Plot.cs
+++ b/Assets/Scripts/ConversationSystem/Plot.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Plot : MonoBehaviour {
+    [SerializeField]
+    string plotName;
+
+    [SerializeField]
+    string startingValue;
+
+    [SerializeField]
+    string plotValue;
+
+    public string getPlotValue () {
+        return this.plotValue;
+    }
+
+    public void setPlotValue (string newValue) {
+        this.plotValue = newValue;
+    }
+}

--- a/Assets/Scripts/ConversationSystem/Plot.cs.meta
+++ b/Assets/Scripts/ConversationSystem/Plot.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b1aa36ea8885425bb7eca3914c9f993
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ConversationSystem/PlotFilter.cs
+++ b/Assets/Scripts/ConversationSystem/PlotFilter.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlotFilter : MonoBehaviour {
+	[SerializeField]
+	Plot plot;
+
+	[SerializeField]
+	string expectedValue;
+
+	public bool isActive () {
+		return this.plot.getPlotValue () == this.expectedValue;
+	}
+}

--- a/Assets/Scripts/ConversationSystem/PlotFilter.cs.meta
+++ b/Assets/Scripts/ConversationSystem/PlotFilter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 957bb29fdad124ce198b6640437a07fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ConversationSystem/PlotManager.cs
+++ b/Assets/Scripts/ConversationSystem/PlotManager.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlotManager : MonoBehaviour {
+    public static PlotManager instance = null;
+
+    /// <summary>
+    /// Awake is called when the script instance is being loaded.
+    /// </summary>
+    void Awake () {
+        //Check if instance already exists
+        if (instance == null) {
+
+            //if not, set instance to this
+            instance = this;
+
+            //If instance already exists and it's not this:
+        } else if (instance != this) {
+
+            //Then destroy this. This enforces our singleton pattern, meaning there can only ever be one instance of a GameManager.
+            Destroy (gameObject);
+        }
+        //Sets this to not be destroyed when reloading scene
+        DontDestroyOnLoad (gameObject);
+    }
+}

--- a/Assets/Scripts/ConversationSystem/PlotManager.cs.meta
+++ b/Assets/Scripts/ConversationSystem/PlotManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b673eadbe6ce64660bc74f9a4fd55e98
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ConversationSystem/PlotTrigger.cs
+++ b/Assets/Scripts/ConversationSystem/PlotTrigger.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlotTrigger : MonoBehaviour
+{
+
+    [SerializeField]
+    Plot plot;
+
+    [SerializeField]
+    string newValue;
+
+    public Plot getPlot()
+    {
+        return this.plot;
+    }
+
+    public string getNewValue()
+    {
+        return this.newValue;
+    }
+}

--- a/Assets/Scripts/ConversationSystem/PlotTrigger.cs.meta
+++ b/Assets/Scripts/ConversationSystem/PlotTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48538c378bf8b4038ab71086eb35002c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Plot triggers can be attached to player choices, and used to filter NPC responses later in the game. Added the ability to link an NPC dialog from a different part of the tree structure and carry on the conversation from that point. Plots are managed across the game and across scenes by a plot manager singleton.